### PR TITLE
Turn timeout off by default

### DIFF
--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -55,6 +55,8 @@ function _setTimeout(
   this: Logger<LambdaContext> & TimeoutLogger,
   context: Context
 ) {
+  const enable = process.env.CAZOO_ENABLE_TIMEOUT_LOGGING;
+  if (!enable || enable.toLowerCase() === 'false') return;
   if (this.timeoutHandle) return;
   if (!('getRemainingTimeInMillis' in context)) return;
   const timeoutMs = context.getRemainingTimeInMillis() - getTimeoutBuffer();

--- a/test/timeout.test.ts
+++ b/test/timeout.test.ts
@@ -53,14 +53,15 @@ describe('Preemptive logging of lambda timeouts', () => {
     stream = sink();
   });
 
+  beforeAll(() => (process.env.CAZOO_ENABLE_TIMEOUT_LOGGING = 'yep'));
+  afterAll(() => delete process.env.CAZOO_ENABLE_TIMEOUT_LOGGING);
+
   const getLogger = (timeout: number) => {
     const context = {
       getRemainingTimeInMillis: (): number => timeout,
     } as Context;
     return logger.fromContext(event, context, {stream, level});
   };
-
-  afterEach(() => delete process.env.CAZOO_LOGGER_TIMEOUT_BUFFER_MS);
 
   describe('when taking the timeout from context', () => {
     it('should not log before the timeout expires', () => {


### PR DESCRIPTION
Enable timeout with environment variable `CAZOO_ENABLE_TIMEOUT_LOGGING`

- [ ] TODO? Add test(s) for when `CAZOO_ENABLE_TIMEOUT_LOGGING` is `undefined` or `'false'`
- [ ] TODO Update Readme/Docs - when is it necessary to use the timeout?